### PR TITLE
feat: adds initial profanity filter

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "web",
 			"version": "0.0.0",
 			"dependencies": {
+				"@2toad/profanity": "^3.2.0",
 				"@tailwindcss/vite": "^4.1.13",
 				"formik": "^2.4.6",
 				"react": "^19.1.1",
@@ -29,6 +30,15 @@
 				"vite": "^7.1.2",
 				"vite-plugin-svgr": "^4.5.0",
 				"wrangler": "^4.39.0"
+			}
+		},
+		"node_modules/@2toad/profanity": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@2toad/profanity/-/profanity-3.2.0.tgz",
+			"integrity": "sha512-1wF0F9SXBS8zsn74ZyDKhClSH+5Tupycq2F1x34+/1YKhrq49ejs+imH8/YIS/JwXoj2oUY+KTpoyOxJeNA2mQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
 		"deploy": "npm run build && wrangler deploy"
 	},
 	"dependencies": {
+		"@2toad/profanity": "^3.2.0",
 		"@tailwindcss/vite": "^4.1.13",
 		"formik": "^2.4.6",
 		"react": "^19.1.1",

--- a/web/src/components/ColorForm/colorForm.schema.js
+++ b/web/src/components/ColorForm/colorForm.schema.js
@@ -1,6 +1,13 @@
 import { number, object, string} from 'yup';
+import { Profanity } from '@2toad/profanity';
 
-const twitch_user_req = /^[a-zA-Z0-9_]+$/;
+const twitch_user_req = /^[a-zA-Z0-9_\s]+$/;
+const special_chars = /[\s_]/;
+
+const profanity = new Profanity({
+    wholeWord: false
+});
+profanity.whitelist.addWords(['test']);
 
 export const colorFormSchema = object({
     username: string()
@@ -10,6 +17,11 @@ export const colorFormSchema = object({
         .matches(
             twitch_user_req,
             'Username can only contain alphanumeric characters'
+        )
+        .test(
+            'is-clean',
+            'Username contains inappropriate language',
+            (value) => !profanity.exists(value.replace(special_chars,''))
         ),
     color: object({
         r: number().required().min(0).max(255),


### PR DESCRIPTION
Closes #29 

Uses [2Toad profanity](https://github.com/2Toad/Profanity) to check for bad words. Bundled in with yup schema to block any form submissions on the frontend. 

Also lets you include space in your name.

Currently only supports English. I tried adding [all supported languages](https://github.com/2Toad/Profanity/blob/main/supported-languages.md), but that blocked almost anything 😅 maybe future enhancement would be to specify profanity language based on [user's language preference](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language).