### PR TITLE
feat: ui restyling to improve mobile friendliness

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2,7 +2,7 @@ import { Footer, MainContent } from './layout';
 import InfoButton from './components/InfoButton';
 
 const App = () => (
-  <div className="flex flex-col h-screen justify-between">
+  <div className="flex flex-col min-h-dvh justify-between">
     <InfoButton />
     <MainContent />
     <Footer />

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -3,9 +3,9 @@ import InfoButton from './components/InfoButton';
 
 const App = () => (
   <div className="flex flex-col min-h-dvh justify-between">
-    <InfoButton />
     <MainContent />
     <Footer />
+    <InfoButton />
   </div>
 )
 

--- a/web/src/components/ColorForm/ColorForm.jsx
+++ b/web/src/components/ColorForm/ColorForm.jsx
@@ -82,7 +82,7 @@ export const ColorForm = () => {
     };
 
 
-    return <div className="px-6 md:mr-12 md:w-112">
+    return <div className="sm:px-6 md:mr-12 md:w-112">
         <Formik initialValues={{
             username: '',
             color: {
@@ -97,7 +97,7 @@ export const ColorForm = () => {
             <Form>
                 <div className="flex flex-col space-y-8">
                     <div className="flex flex-col space-y-4">
-                        <Field id='username' name='username' placeholder='Name' className="form-field pl-4 placeholder-bone" />
+                        <Field id='username' name='username' placeholder='Name' className="text-sm sm:text-base form-field pl-4 py-2 placeholder-bone" />
                         <ErrorMessage name='username' component="span" className="text-bone" />
                         <ColorInput />
                     </div>

--- a/web/src/components/InfoButton/InfoButton.jsx
+++ b/web/src/components/InfoButton/InfoButton.jsx
@@ -20,7 +20,7 @@ export const InfoButton = () => {
             {/* Tooltip Popup */}
             {showTooltip && (
                 <div className="absolute z-50 -left-64 top-0 w-64 p-4 bg-arcana-900/95 border border-pumpkin-400 rounded-lg shadow-lg backdrop-blur-sm transition-all duration-200 ease-out">
-                    <div className="text-bone text-sm leading-relaxed">
+                    <div className="text-bone text-xs leading-relaxed">
                         <h3 className="font-bold text-base mb-2">The Project</h3>
                         <p className="mb-2">
                             This project controls a physical LED strip in real-time! When you submit a color, it gets added to a queue.

--- a/web/src/layout/MainContent.jsx
+++ b/web/src/layout/MainContent.jsx
@@ -4,15 +4,13 @@ import LogoIcon from '../assets/pumpkin.svg?react';
 
 export const MainContent = () => (
     <div id="main-content" className="main-content">
-        <div className="flex flex-col items-center justify-center">
-            <LogoIcon viewBox="0 0 441 409" width="128" height="128" />
-            <h1 className="text-bone text-md font-bold text-center">RGBOO</h1>
+        <div className="flex sm:flex-col items-center sm:justify-center gap-4">
+            <LogoIcon viewBox="0 0 441 409" className="w-10 h-10 sm:w-24 sm:h-24" />
+            <h1 className="m-0 leading-none text-bone text-sm sm:text-md font-bold text-center translate-y-1 sm:translate-y-0">RGBOO</h1>
         </div>
         <div className="flex flex-col md:flex-row-reverse justify-center md:items-start gap-12 md:gap-8">
             <div className="w-full md:flex-1 max-w-2xl">
-                <div className="mb-4 md:mb-0">
-                    <TwitchEmbed channel="roddzillaaa" />
-                </div>
+                <TwitchEmbed channel="roddzillaaa" />
             </div>
             <div className="w-full md:w-auto md:flex-shrink-0">
                 <ColorForm />

--- a/web/src/theme.css
+++ b/web/src/theme.css
@@ -13,6 +13,7 @@
   --color-arcana-900: #160B1A;
 
   --text-base: 2rem;
+  --text-sm: 1.75rem;
   --text-md: 3rem;
 }
 
@@ -22,7 +23,7 @@
   }
 
   .main-content {
-    @apply flex flex-col justify-center mt-12 mb-auto px-12 space-y-10;
+    @apply flex flex-col justify-center mt-12 mb-auto px-12 gap-8 sm:gap-10;
   }
 
   .info-icon {
@@ -41,8 +42,12 @@
     @apply text-base md:text-md font-bold text-bone border-1 border-pumpkin-400 rounded-md
   }
 
+  .form-button {
+    @apply text-sm sm:text-base py-2;
+  }
+
   .form-button:hover, .form-button:active {
-    @apply text-arcana-900 bg-linear-to-r from-pumpkin-400 to-pumpkin-600;
+    @apply text-arcana-900 bg-linear-to-r from-pumpkin-400 to-pumpkin-600 transition-colors;
   }
 
   .footer {


### PR DESCRIPTION
Closes #32 

- Fixes mobile styling on most screen sizes (except for iPhone SE 🫠)
- Consolidated spacing to be consistent across breakpoints.
- Changed logo to be row on smaller screen sizes to conserve space.