### PR TITLE
fix: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,1 @@
-* @alexteal
-* @arugyani
-* @vray8
-* @nrodd
-* @NeoBaneling
-* @danngo342
+* @alexteal @arugyani @vray8 @nrodd @NeoBaneling @danngo342


### PR DESCRIPTION
i think this is the right syntax lol.

in the future we could have one github team that gets marked so it's a little easier to manage, but this works for now.